### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/cmd.py
+++ b/cmd.py
@@ -54,7 +54,7 @@ def usage(e=None):
         print >> sys.stderr, 'Error: ' + str(e)
 
     cmd = os.path.basename(sys.argv[0])
-    print >> sys.stderr, 'Syntax: %s method uri [arg=val...]' % cmd
+    print >> sys.stderr, 'Syntax: {0!s} method uri [arg=val...]'.format(cmd)
     print >> sys.stderr, __doc__.strip()
 
     sys.exit(1)

--- a/contrib/gist/gist.py
+++ b/contrib/gist/gist.py
@@ -51,7 +51,7 @@ def usage(e=None):
         print >> sys.stderr, 'Error: ' + str(e)
 
     cmd = os.path.basename(sys.argv[0])
-    print >> sys.stderr, 'Syntax: %s [-options] [file...fileN]' % cmd
+    print >> sys.stderr, 'Syntax: {0!s} [-options] [file...fileN]'.format(cmd)
     print >> sys.stderr, __doc__.lstrip()
 
     sys.exit(1)
@@ -59,7 +59,7 @@ def usage(e=None):
 def render_gist(gist):
     files = ' '.join(gist.files.keys()).encode('ascii', 'ignore').strip()
     visible = 'pub' if gist.public else 'sec'
-    return '[%s] %s %s' % (visible, gist.html_url, files)
+    return '[{0!s}] {1!s} {2!s}'.format(visible, gist.html_url, files)
 
 def get_gists(token, uri):
     max_pages = 0 if token else 1
@@ -123,7 +123,7 @@ def main():
     paths = args
     for path in paths:
         if not os.path.exists(path):
-            fatal('does not exist: %s' % path)
+            fatal('does not exist: {0!s}'.format(path))
 
     if len(paths) == 0:
         for gist in get_gists(token, uri):

--- a/contrib/offline-issues/parse.py
+++ b/contrib/offline-issues/parse.py
@@ -44,7 +44,7 @@ def usage(e=None):
     if e:
         print >> sys.stderr, 'Error:', e
 
-    print >> sys.stderr, 'Syntax: %s [-options] issues.json outdir' % sys.argv[0]
+    print >> sys.stderr, 'Syntax: {0!s} [-options] issues.json outdir'.format(sys.argv[0])
     print >> sys.stderr, __doc__.strip()
 
     sys.exit(1)
@@ -73,7 +73,7 @@ def output_issues(issues, outdir):
         slug = slugify(issue.title)
 
         path = os.path.join(outdir, 'all', str(issue.number))
-        path_symlink = '../../all/%s' % str(issue.number)
+        path_symlink = '../../all/{0!s}'.format(str(issue.number))
         mkdir(os.path.dirname(path))
         file(path, 'w').write(json.dumps(issue, indent=1))
 
@@ -112,7 +112,7 @@ def main():
     outdir = args[1]
 
     if not os.path.exists(infile):
-        fatal('path does not exist: %s' % infile)
+        fatal('path does not exist: {0!s}'.format(infile))
 
     if init:
         for dir in ('state', 'labels', 'assignee'):

--- a/contrib/pull-requests/list.py
+++ b/contrib/pull-requests/list.py
@@ -40,7 +40,7 @@ def usage(e=None):
         print >> sys.stderr, 'Error: ' + str(e)
 
     cmd = os.path.basename(sys.argv[0])
-    print >> sys.stderr, 'Syntax: %s [-options] owner[/repo]' % cmd
+    print >> sys.stderr, 'Syntax: {0!s} [-options] owner[/repo]'.format(cmd)
     print >> sys.stderr, __doc__.lstrip()
 
     sys.exit(1)
@@ -89,17 +89,17 @@ def main():
     else:
         owner = args[0]
         try:
-            repos = get_repos(conn, '/orgs/%s/repos' % owner)
+            repos = get_repos(conn, '/orgs/{0!s}/repos'.format(owner))
         except ResponseError, e:
-            repos = get_repos(conn, '/users/%s/repos' % owner)
+            repos = get_repos(conn, '/users/{0!s}/repos'.format(owner))
 
     for repo in repos:
-        response = conn.send('GET', '/repos/%s/%s/pulls' % (owner, repo))
+        response = conn.send('GET', '/repos/{0!s}/{1!s}/pulls'.format(owner, repo))
         if response.parsed:
-            print '%s/%s\n' % (owner, repo)
+            print '{0!s}/{1!s}\n'.format(owner, repo)
             for pull in response.parsed:
-                print '  [%s] %s' % (pull.head.user.login, pull.title)
-                print '  %s' % pull.html_url
+                print '  [{0!s}] {1!s}'.format(pull.head.user.login, pull.title)
+                print '  {0!s}'.format(pull.html_url)
                 print
 
 

--- a/octohub/__init__.py
+++ b/octohub/__init__.py
@@ -8,5 +8,5 @@
 # version.
 
 __version__ = '0.1'
-__useragent__ = 'octohub/%s' % __version__
+__useragent__ = 'octohub/{0!s}'.format(__version__)
 

--- a/octohub/connection.py
+++ b/octohub/connection.py
@@ -53,7 +53,7 @@ class Connection(object):
         self.headers = {'User-Agent': __useragent__}
 
         if token:
-            self.headers['Authorization'] = 'token %s' % token
+            self.headers['Authorization'] = 'token {0!s}'.format(token)
 
     def send(self, method, uri, params={}, data=None):
         """Prepare and send request

--- a/octohub/response.py
+++ b/octohub/response.py
@@ -41,7 +41,7 @@ def _parse_link(header_link):
         rel = m.groups()[0]
 
         links[rel] = link
-        log.debug('link-%s-page: %s' % (rel, link.params['page']))
+        log.debug('link-{0!s}-page: {1!s}'.format(rel, link.params['page']))
 
     return links
 
@@ -82,7 +82,7 @@ def parse_response(response):
     headers = ['status', 'x-ratelimit-limit', 'x-ratelimit-remaining']
     for header in headers:
         if header in response.headers.keys():
-            log.info('%s: %s' % (header, response.headers[header]))
+            log.info('{0!s}: {1!s}'.format(header, response.headers[header]))
 
     content_type = _get_content_type(response)
 
@@ -93,7 +93,7 @@ def parse_response(response):
         response.parsed = parse_element(json)
     else:
         if not response.status_code == 204:
-            raise OctoHubError('unhandled content_type: %s' % content_type)
+            raise OctoHubError('unhandled content_type: {0!s}'.format(content_type))
 
     if not response.status_code in (200, 201, 204):
         raise ResponseError(response.parsed)

--- a/octohub/utils.py
+++ b/octohub/utils.py
@@ -15,7 +15,7 @@ class AttrDict(dict):
     def __getattr__(self, name):
         if name in self:
             return self[name]
-        raise AttributeError('no such attribute: %s' % name)
+        raise AttributeError('no such attribute: {0!s}'.format(name))
 
     def __setattr__(self, name, val):
         self[name] = val


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:octohub?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:octohub?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
